### PR TITLE
Fixed the conditional get_contract dry-run workaround.

### DIFF
--- a/contracts/models/emit_event.ligo
+++ b/contracts/models/emit_event.ligo
@@ -1,9 +1,7 @@
 #include "../types/ovm_event_types.ligo"
 
 function dry_tx(const placeholder:unit) : operation is 
-begin 
-  const op : operation = transaction(unit, 0mutez, ( get_contract(source) : contract(unit) ));
-end with op;
+begin skip end with transaction(unit, 0mutez, ( get_contract(source) : contract(unit) ));
 
 function emit_event(
   const event_receiver_address: address;

--- a/contracts/models/emit_event.ligo
+++ b/contracts/models/emit_event.ligo
@@ -6,10 +6,13 @@ function emit_event(
   const params: event_params
 ) : operation is
 begin
-  const event_receiver : contract(event_action) = get_contract(event_receiver_address);
-  const event: event_action = record
-    topic = topic;
-    params = params;
-  end;  
-  const op: operation = transaction(event, 0mutez, event_receiver);
+  const isDryRun:bool = True;
+  const op: operation = if isDryRun then
+    transaction(unit, 0mutez, ( get_contract(source) : contract(unit) ));
+  else
+    transaction(record
+      topic = topic;
+      params = params;
+    end, 0mutez, ( get_contract(event_receiver_address) : contract(event_action) ));
+
 end with op;

--- a/contracts/models/emit_event.ligo
+++ b/contracts/models/emit_event.ligo
@@ -1,18 +1,24 @@
 #include "../types/ovm_event_types.ligo"
 
+function dry_tx(const placeholder:unit) : operation is 
+begin 
+  const op : operation = transaction(unit, 0mutez, ( get_contract(source) : contract(unit) ));
+end with op;
+
 function emit_event(
   const event_receiver_address: address;
   const topic: string;
   const params: event_params
 ) : operation is
 begin
-  const isDryRun:bool = True;
-  const op: operation = if isDryRun then
-    transaction(unit, 0mutez, ( get_contract(source) : contract(unit) ));
-  else
-    transaction(record
-      topic = topic;
-      params = params;
-    end, 0mutez, ( get_contract(event_receiver_address) : contract(event_action) ));
+  const is_prod:bool = False; //TODO: From storage.is_prod
 
+  const event: event_action = record
+    topic = topic;
+    params = params;
+  end;
+
+  const op: operation = if is_prod then
+    transaction(event, 0mutez, ( get_contract(event_receiver_address) : contract(event_action) ));
+  else dry_tx(unit);
 end with op;


### PR DESCRIPTION
This code enabled me to return Operations(...bytes) output.

```
{"status":"ok","content":"( [ Operation(...bytes) ] , {operator_address = address \"tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV\" , events = [ \n  +0 -> [ \"BlockSubmitted\" -> [ {data = SubmittedEvent(( +0 , \"root\" )) , block_height = +0} ] ] ] , event_receiver_address = address \"KT1T2Zy4THwShihhqsaFWTubUVnFmjddHzew\" , current_block = +1 , commitments = [ \n  +0 -> \"root\" ; +1 -> \"root1\" ] , branches = [ address \"tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV\" -> {total_deposited = +0 , deposited_ranges = [ \n                                                +0 -> {start_ = +0 , end_ = +0} ] , claims = [ \n                                                \"hoge\" -> {property = {predicate_address = address \"tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV\" , inputs = [ \n                                                +0 -> \"hoge\" ]} , num_proven_contradictions = +1 , decided_after = +1} ] , checkpoints = [ \n                                                0x0001 -> {subrange = {start_ = +1 , end_ = +1} , state_update = {range = {start_ = +1 , end_ = +1} , property = {predicate_address = address \"tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV\" , inputs = [ 
```