### PR TITLE
add finalize checkpoint

### DIFF
--- a/contracts/actions/deposit.ligo
+++ b/contracts/actions/deposit.ligo
@@ -27,11 +27,11 @@ begin
   const state_update: property = record
     // TODO: Injecting StateUpdate predicate address
     predicate_address = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV" : address);
-    inputs = list
-      encode_address(deposit_params.token_type);
-      encode_range(deposited_range);
-      encode_number(s.current_block);
-      encode_property(deposit_params.state_object);
+    inputs = map
+      0n -> encode_address(deposit_params.token_type);
+      1n -> encode_range(deposited_range);
+      2n -> encode_number(s.current_block);
+      3n -> encode_property(deposit_params.state_object);
     end;
   end;
 

--- a/contracts/actions/finalize_checkpoint.ligo
+++ b/contracts/actions/finalize_checkpoint.ligo
@@ -14,6 +14,8 @@ begin
     state_update = decode_property(get_force(1n, finalize_checkpoint_params.checkpoint_property.inputs));
   end;
 
+  s := store_checkpoint(s, finalize_checkpoint_params.token_type, checkpoint);
+
   const checkpoint_finalized_event: event_params = CheckpointFinalizedEvent(
     (
       finalize_checkpoint_params.token_type,

--- a/contracts/actions/finalize_checkpoint.ligo
+++ b/contracts/actions/finalize_checkpoint.ligo
@@ -1,0 +1,26 @@
+#include "../types/index.ligo"
+#include "../models/get_checkpoint_id.ligo"
+#include "../utils/primitive_coder.ligo"
+
+function finalize_checkpoint_action(
+  const finalize_checkpoint_params: finalize_checkpoint_params;
+  const s: ovm_storage
+) : context is
+begin
+
+  // TODO: check adjudication.isDecided(checkpoint)
+  const checkpoint: checkpoint = record
+    subrange = decode_range(get_force(0n, finalize_checkpoint_params.checkpoint_property.inputs));
+    state_update = decode_property(get_force(1n, finalize_checkpoint_params.checkpoint_property.inputs));
+  end;
+
+  const checkpoint_finalized_event: event_params = CheckpointFinalizedEvent(
+    (
+      finalize_checkpoint_params.token_type,
+      get_checkpoint_id(checkpoint),
+      checkpoint
+    )
+  );
+
+  s.events_storage := emit_event(s.events_storage, "CheckpointFinalized", checkpoint_finalized_event);
+end with ((nil : ops), s)

--- a/contracts/actions/index.ligo
+++ b/contracts/actions/index.ligo
@@ -1,2 +1,3 @@
 #include "commitment.ligo"
 #include "deposit.ligo"
+#include "finalize_checkpoint.ligo"

--- a/contracts/main.ligo
+++ b/contracts/main.ligo
@@ -5,5 +5,6 @@ function main (const action: action; const s: ovm_storage) : context is
   block {skip} with
   case action of
     | Deposit(deposit_params) -> deposit_action(deposit_params, s)
+    | FinalizeCheckpoint(finalize_checkpoint_params) -> finalize_checkpoint_action(finalize_checkpoint_params, s)
     | Submit(submit_params) -> submit_action(submit_params, s)
   end

--- a/contracts/types/ovm_action_types.ligo
+++ b/contracts/types/ovm_action_types.ligo
@@ -11,13 +11,14 @@ type deposit_params is record
 end
 
 type finalize_checkpoint_params is record
-  token_type: bytes;
-  amount: nat;
+  token_type: token_type;
+  checkpoint_property: property;
 end
 
 type finalize_exit_params is record
-  token_type: bytes;
-  amount: nat;
+  token_type: token_type;
+  exit_property: property;
+  deposited_range_id: nat;
 end
 
 // commitment contract
@@ -26,6 +27,14 @@ type submit_params is record
   root: string;
 end
 
+// adjudication contract
+type claim_property_params is record
+  claim: property;
+end
+
 type action is
   | Deposit of deposit_params
+  | FinalizeCheckpoint of finalize_checkpoint_params
+//  | FinalizeExit of finalize_exit_params
   | Submit of submit_params
+//  | ClaimProperty of claim_property_params

--- a/contracts/types/ovm_primitive_types.ligo
+++ b/contracts/types/ovm_primitive_types.ligo
@@ -6,7 +6,7 @@ end
 // Property
 type property is record
   predicate_address: address;
-  inputs: list(bytes);
+  inputs: map(nat, bytes);
 end
 
 type state_update is record

--- a/contracts/utils/primitive_coder.ligo
+++ b/contracts/utils/primitive_coder.ligo
@@ -49,3 +49,6 @@ begin
     | None -> failwith("decode error")
   end;
 end with unpacked_property
+
+function pack_property (const action: property; const s: bytes) : (ops * bytes) is
+begin skip end with ((nil:ops), encode_property(action))

--- a/contracts/utils/primitive_coder.ligo
+++ b/contracts/utils/primitive_coder.ligo
@@ -15,27 +15,37 @@ begin skip end with (bytes_unpack(bytes) : option(nat));
 function encode_range(const range: range) : bytes is
 begin skip end with bytes_pack((range.start_, range.end_));
 
-function decode_range(const bytes: bytes) : option(range) is
+function decode_range(const bytes: bytes) : range is
 begin
-  const r_opt : option((nat * nat)) = bytes_unpack(bytes);
-end with case r_opt of
-  | Some(p) -> Some(record
-    start_ = p.0;
-    end_ = p.1;
-  end)
-  | None -> (None : option(range))
-end
+  const unpacked_opt : option((nat * nat)) = bytes_unpack(bytes);
+  const unpacked_range: range = record
+    start_ = 0n;
+    end_ = 0n;
+  end;
+  case unpacked_opt of
+    | Some(r) -> unpacked_range := record
+      start_ = r.0;
+      end_ = r.1;
+    end
+    | None -> failwith("decode error")
+  end;
+end with unpacked_range
 
 function encode_property(const property: property) : bytes is
 begin skip end with bytes_pack((property.predicate_address, property.inputs));
 
-function decode_property(const bytes: bytes) : option(property) is
+function decode_property(const bytes: bytes) : property is
 begin
-  const p_opt : option((address * list(bytes))) = bytes_unpack(bytes);
-end with case p_opt of
-  | Some(p) -> Some(record
-    predicate_address = p.0;
-    inputs = p.1;
-  end)
-  | None -> (None : option(property))
-end
+  const unpacked_opt : option((address * map(nat, bytes))) = bytes_unpack(bytes);
+  const unpacked_property: property = record
+    predicate_address = source;
+    inputs = (map end: map(nat, bytes));
+  end;
+  case unpacked_opt of
+    | Some(p) -> unpacked_property := record
+      predicate_address = p.0;
+      inputs = p.1;
+    end
+    | None -> failwith("decode error")
+  end;
+end with unpacked_property

--- a/test/codec.test.js
+++ b/test/codec.test.js
@@ -51,10 +51,14 @@ describe('CodecContract', function() {
       })
 
       it('packs a property record', async () => {
-        const packParam = `record
-          predicate_address = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV" : address);
-          inputs = list ("0001" : bytes); ("0002" : bytes); end;
-        end`
+        const packParam = `(
+          ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV": address),
+          map
+            0n -> ("0001": bytes);
+            1n -> ("0002": bytes);
+          end
+        )`
+
         const result = await invokeTest({
           contractPath: CONTRACT_PATH,
           parameter: packParam,
@@ -63,8 +67,7 @@ describe('CodecContract', function() {
         })
         assert.deepEqual(
           result.postState,
-          '0x050707020000000e0a0000000200010a0000000200020a00000016000053c1edca8bd5c21c61d6' +
-            'f1fd091fa51d562aff1d'
+          '0x0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d0200000016070400000a000000020001070400010a000000020002'
         )
       })
 
@@ -219,7 +222,7 @@ describe('CodecContract', function() {
       })
 
       it('unpacks a property record', async () => {
-        const packParam = `("050707020000000e0a0000000200010a0000000200020a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d":bytes)`
+        const packParam = `("0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d0200000016070400000a000000020001070400010a000000020002":bytes)`
         const result = await invokeTest({
           contractPath: CONTRACT_PATH,
           parameter: packParam,
@@ -228,10 +231,10 @@ describe('CodecContract', function() {
         })
         assert.deepEqual(result.postState, [
           'SOME',
-          {
-            predicate_address: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV',
-            inputs: ['0x0001', '0x0002']
-          }
+          [
+            'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV',
+            { '0': '0x0001', '1': '0x0002' }
+          ]
         ])
       })
 

--- a/test/contracts/codec.ligo
+++ b/test/contracts/codec.ligo
@@ -4,10 +4,7 @@ type sample_record is record
   attributeA: string;
   attributeB: nat;
 end
-type property_record is record
-  predicate_address: address;
-  inputs: list(bytes);
-end
+type property_record is (address * map(nat, bytes))
 type sample_tuple is (address * list(bytes))
 
 ////////////////

--- a/test/deposit.test.js
+++ b/test/deposit.test.js
@@ -12,7 +12,7 @@ describe('DepositContract', function() {
     amount = 1n;
     state_object = record
       predicate_address = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV":address);
-      inputs = list ("050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d":bytes) end;
+      inputs = map 0n -> ("050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d":bytes) end;
     end;
   end
 )`)
@@ -34,17 +34,19 @@ describe('DepositContract', function() {
               'CheckpointFinalizedEvent',
               [
                 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV',
-                '0xf03c32adb499a382c66dee12e091b94f587646f692fa115d55c668e6f22a8429',
+                '0xce6170f820c3599b11cf1d9f606522c8b03ddce4c9ca4c6dbcd30d10f3099e14',
                 {
                   subrange: { start_: 1, end_: 2 },
                   state_update: {
                     predicate_address: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV',
-                    inputs: [
-                      '0x050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d',
-                      '0x05070700010002',
-                      '0x050000',
-                      '0x0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d02000000210a0000001c050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d'
-                    ]
+                    inputs: {
+                      '0':
+                        '0x050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d',
+                      '1': '0x05070700010002',
+                      '2': '0x050000',
+                      '3':
+                        '0x0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d0200000025070400000a0000001c050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d'
+                    }
                   }
                 }
               ]

--- a/test/deposit.test.js
+++ b/test/deposit.test.js
@@ -77,4 +77,69 @@ describe('DepositContract', function() {
       assert.equal(result.status, STATUS.OK)
     })
   })
+
+  describe('FinalizeCheckpoint', () => {
+    const testParams = rmWhiteSpaces(`FinalizeCheckpoint(
+  record
+	  token_type = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV":address);
+    checkpoint_property = record
+      predicate_address = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV": address);
+      inputs = map
+        0n -> ("05070700010002": bytes);
+        1n -> ("0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d0200000092070400000a0000001c050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d070400010a0000000705070700010002070400020a00000003050000070400030a000000480507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d0200000025070400000a0000001c050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d": bytes);
+      end;
+    end;
+  end
+)`)
+
+    it('finalize checkpoint 1 to 2', async () => {
+      const result = await invokeTest({
+        parameter: testParams,
+        initialStorage,
+        source: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV',
+        sender: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV'
+      })
+      assert.deepEqual(
+        result.postState.events_storage.events.CheckpointFinalized,
+        [
+          {
+            data: [
+              'CheckpointFinalizedEvent',
+              [
+                'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV',
+                '0xce6170f820c3599b11cf1d9f606522c8b03ddce4c9ca4c6dbcd30d10f3099e14',
+                {
+                  subrange: { start_: 1, end_: 2 },
+                  state_update: {
+                    predicate_address: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV',
+                    inputs: {
+                      '0':
+                        '0x050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d',
+                      '1': '0x05070700010002',
+                      '2': '0x050000',
+                      '3':
+                        '0x0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d0200000025070400000a0000001c050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d'
+                    }
+                  }
+                }
+              ]
+            ],
+            block_height: 0
+          }
+        ]
+      )
+
+      assert.deepEqual(
+        result.postState.branches['tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV']
+          .deposited_ranges,
+        []
+      )
+
+      assert.equal(
+        result.postState.branches['tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV']
+          .total_deposited,
+        2
+      )
+    })
+  })
 })

--- a/test/deposit.test.js
+++ b/test/deposit.test.js
@@ -128,18 +128,6 @@ describe('DepositContract', function() {
           }
         ]
       )
-
-      assert.deepEqual(
-        result.postState.branches['tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV']
-          .deposited_ranges,
-        []
-      )
-
-      assert.equal(
-        result.postState.branches['tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV']
-          .total_deposited,
-        2
-      )
     })
   })
 })

--- a/test/testdata/initial_storage
+++ b/test/testdata/initial_storage
@@ -12,7 +12,7 @@ record
         "hoge" -> record
           property = record
             predicate_address = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV": address);
-            inputs = list ("0102": bytes) end;
+            inputs = map 0n -> ("0102": bytes) end;
           end;
           num_proven_contradictions = 1n;
           decided_after = 1n;
@@ -26,11 +26,11 @@ record
           end;
           state_update = record
             predicate_address = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV": address);
-            inputs = list
-              ("050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d": bytes);
-              ("05070700000001": bytes);
-              ("050000": bytes);
-              ("0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d02000000210a0000001c050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d": bytes);
+            inputs = map
+              0n -> ("050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d": bytes);
+              1n -> ("05070700000001": bytes);
+              2n -> ("050000": bytes);
+              3n -> ("0507070a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d02000000210a0000001c050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d": bytes);
             end;
           end;
         end;


### PR DESCRIPTION
using map(nat, bytes) for inputs list because we can't get an item with `list[index]`.