### PR TITLE
Feat/32/verify inclusion

### DIFF
--- a/contracts/models/verify_inclusion.ligo
+++ b/contracts/models/verify_inclusion.ligo
@@ -47,7 +47,7 @@ function compute_interval_tree_root(
   const proof: map(nat, interval_tree_node)
 ) : (bytes * nat) is
 begin
-  var first_right_sibling_start: nat := 1000n;
+  var first_right_sibling_start: nat := 99999n;
   var is_first_right_set: bool := False;
   var tmp_merkle_path: nat := merkle_path;
   for i := 1 to int(size(proof))

--- a/contracts/models/verify_inclusion.ligo
+++ b/contracts/models/verify_inclusion.ligo
@@ -38,8 +38,7 @@ begin
   if right_start >= left_start
   then skip
   else failwith("left_start must be less than right_start");
-  // TODO hash(left, left_start, right, right_start)
-end with ("0000": bytes);
+end with sha_256(bytes_concat(bytes_concat(bytes_concat(left, bytes_pack(left_start)), right), bytes_pack(right_start)));
 
 function compute_interval_tree_root(
   var computed_root: bytes;
@@ -98,5 +97,8 @@ begin
         "required range must not exceed the implicit range"
     );
   *)
+  if range.end_ <= root_and_implicit_end.1
+  then skip
+  else failwith("required range must not exceed the implicit range");
   // TODO: skip address tree verification in tezos
 end with root_and_implicit_end.0 = root;

--- a/contracts/models/verify_inclusion.ligo
+++ b/contracts/models/verify_inclusion.ligo
@@ -89,15 +89,7 @@ begin
       inclusion_proof.interval_inclusion_proof.leaf_position,
       inclusion_proof.interval_inclusion_proof.siblings
   );
-  // TODO: assert range
-  (*
-    require(
-        _range.start >= _inclusionProof.intervalInclusionProof.leafIndex &&
-            _range.end <= implicitEnd,
-        "required range must not exceed the implicit range"
-    );
-  *)
-  if range.end_ <= root_and_implicit_end.1
+  if range.start_ >= inclusion_proof.interval_inclusion_proof.leaf_index and range.end_ <= root_and_implicit_end.1
   then skip
   else failwith("required range must not exceed the implicit range");
   // TODO: skip address tree verification in tezos

--- a/contracts/models/verify_inclusion.ligo
+++ b/contracts/models/verify_inclusion.ligo
@@ -1,0 +1,102 @@
+#include "../types/index.ligo"
+
+type address_tree_node is record
+  data: bytes;
+  address: address;
+end
+
+// TODO: interval_tree_node is encoded by original encoder
+type interval_tree_node is record
+  data: bytes;
+  start: nat;
+end
+
+type address_inclusion_proof is record
+  leaf_index: address;
+  leaf_position: nat;
+  siblings: map(nat, address_tree_node)
+end
+
+type interval_inclusion_proof is record
+  leaf_index: nat;
+  leaf_position: nat;
+  siblings: map(nat, interval_tree_node)
+end
+
+type inclusion_proof is record
+  address_inclusion_proof: address_inclusion_proof;
+  interval_inclusion_proof: interval_inclusion_proof;
+end
+
+function get_parent(
+  const left: bytes;
+  const left_start: nat;
+  const right: bytes;
+  const right_start: nat
+) : bytes is
+begin
+  if right_start >= left_start
+  then skip
+  else failwith("left_start must be less than right_start");
+  // TODO hash(left, left_start, right, right_start)
+end with ("0000": bytes);
+
+function compute_interval_tree_root(
+  var computed_root: bytes;
+  var computed_start: nat;
+  const merkle_path: nat;
+  const proof: map(nat, interval_tree_node)
+) : (bytes * nat) is
+begin
+  var first_right_sibling_start: nat := 1000n;
+  var is_first_right_set: bool := False;
+  var tmp_merkle_path: nat := merkle_path;
+  for i := 1 to int(size(proof))
+    begin
+      const a_proof : interval_tree_node = get_force(abs(i - 1), proof);
+      const sibling: bytes = a_proof.data;
+      const sibling_start: nat = a_proof.start;
+      const is_right: nat = tmp_merkle_path mod 2n;
+      tmp_merkle_path := tmp_merkle_path / 2n;
+      if is_right = 1n
+      then computed_root := get_parent(sibling, sibling_start, computed_root, computed_start)
+      else
+      begin
+        if not is_first_right_set
+        then begin
+          first_right_sibling_start := sibling_start;
+          is_first_right_set := True;
+        end else skip;
+        if first_right_sibling_start <= sibling_start
+        then skip
+        else failwith("first_right_sibling_start must be greater than sibling_start");
+        computed_root := get_parent(computed_root, computed_start, sibling, sibling_start);
+        computed_start := sibling_start;
+      end;
+    end
+end with (computed_root, first_right_sibling_start);
+
+function verify_inclusion(
+  const leaf: bytes;
+  const token_address: address;
+  const range: range;
+  const inclusion_proof: inclusion_proof;
+  const root: bytes
+) : bool is
+begin
+  const root_and_implicit_end: (bytes * nat) = compute_interval_tree_root(
+      leaf,
+      inclusion_proof.interval_inclusion_proof.leaf_index,
+      inclusion_proof.interval_inclusion_proof.leaf_position,
+      inclusion_proof.interval_inclusion_proof.siblings
+  );
+  // TODO: assert range
+  (*
+    require(
+        _range.start >= _inclusionProof.intervalInclusionProof.leafIndex &&
+            _range.end <= implicitEnd,
+        "required range must not exceed the implicit range"
+    );
+  *)
+  // TODO: skip address tree verification in tezos
+end with root_and_implicit_end.0 = root;

--- a/contracts/test.ligo
+++ b/contracts/test.ligo
@@ -1,5 +1,6 @@
 #include "types/index.ligo"
 #include "actions/finalize_exit.ligo"
+#include "models/verify_inclusion.ligo"
 
 (* entry point for test *)
 function test_remove_deposited_range(
@@ -7,3 +8,9 @@ function test_remove_deposited_range(
   const s: deposit_storage
 ) : ( ops * deposit_storage ) is
 begin skip end with ( (nil:ops) , remove_deposited_range( s, params.0, params.1))
+
+function test_verify_inclusion(
+  const params: (bytes * address * range * inclusion_proof * bytes);
+  const s: bool
+) : ( ops * bool ) is
+begin skip end with ( (nil:ops) , verify_inclusion( params.0, params.1, params.2, params.3, params.4))

--- a/contracts/test.ligo
+++ b/contracts/test.ligo
@@ -14,3 +14,9 @@ function test_verify_inclusion(
   const s: bool
 ) : ( ops * bool ) is
 begin skip end with ( (nil:ops) , verify_inclusion( params.0, params.1, params.2, params.3, params.4))
+
+function test_compute_interval_tree_root(
+  const params: (bytes * nat * nat * map(nat, interval_tree_node));
+  const s: (bytes * nat)
+) : ( ops * (bytes * nat) ) is
+begin skip end with ( (nil:ops) , compute_interval_tree_root( params.0, params.1, params.2, params.3))

--- a/test/commitment.test.js
+++ b/test/commitment.test.js
@@ -75,13 +75,13 @@ describe('CommitmentContract', function() {
             leaf_position = 0n;
             siblings = (map
               0n -> record
-                data = ("0000": bytes);
+                data = ("0001": bytes);
                 start = 1n;
               end
             end : map(nat, interval_tree_node));
           end;
         end,
-        ("d8d1f8c8073289a8b67d4956bf30fdc4f8319fed2007825b65932f56b9642e94": bytes)
+        ("1195f78192bb227e30b722701870d4e6cd376598ec9eba144ed4e7826ae3c112": bytes)
       )`)
 
       const result = await invokeTest({
@@ -114,13 +114,13 @@ describe('CommitmentContract', function() {
             leaf_position = 0n;
             siblings = (map
               0n -> record
-                data = ("0000": bytes);
+                data = ("0001": bytes);
                 start = 1n;
               end
             end : map(nat, interval_tree_node));
           end;
         end,
-        ("d8d1f8c8073289a8b67d4956bf30fdc4f8319fed2007825b65932f56b9642e94": bytes)
+        ("1195f78192bb227e30b722701870d4e6cd376598ec9eba144ed4e7826ae3c112": bytes)
       )`)
 
       const result = await invokeTest({
@@ -146,7 +146,7 @@ describe('CommitmentContract', function() {
         0n,
         (map
           0n -> record
-            data = ("0000": bytes);
+            data = ("0001": bytes);
             start = 1n;
           end
         end : map(nat, interval_tree_node))
@@ -159,8 +159,34 @@ describe('CommitmentContract', function() {
         source: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV'
       })
       assert.deepEqual(result.postState, [
-        '0xd8d1f8c8073289a8b67d4956bf30fdc4f8319fed2007825b65932f56b9642e94',
+        '0x1195f78192bb227e30b722701870d4e6cd376598ec9eba144ed4e7826ae3c112',
         1
+      ])
+    })
+
+    it('return compute root and implicit end with right leaf', async () => {
+      const initialStorage = rmWhiteSpaces(`(("0000": bytes), 0n)`)
+      const testParams = rmWhiteSpaces(`(
+        ("0001": bytes),
+        1n,
+        1n,
+        (map
+          0n -> record
+            data = ("0000": bytes);
+            start = 0n;
+          end
+        end : map(nat, interval_tree_node))
+      )`)
+      const result = await invokeTest({
+        contractPath: 'contracts/test.ligo',
+        entryPoint: 'test_compute_interval_tree_root',
+        parameter: testParams,
+        initialStorage,
+        source: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV'
+      })
+      assert.deepEqual(result.postState, [
+        '0x1195f78192bb227e30b722701870d4e6cd376598ec9eba144ed4e7826ae3c112',
+        99999
       ])
     })
   })

--- a/test/commitment.test.js
+++ b/test/commitment.test.js
@@ -53,4 +53,45 @@ describe('CommitmentContract', function() {
       assert.deepEqual(result.failwith, 'block_number should be next block')
     })
   })
+
+  describe('verify_inclusion', () => {
+    it('suceed to verify inclusion', async () => {
+      const initialStorage = rmWhiteSpaces(`False`)
+      const testParams = rmWhiteSpaces(`(
+        ("0000": bytes),
+        ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV": address),
+        record
+          start_ = 0n;
+          end_ = 1n;
+        end,
+        record
+          address_inclusion_proof = record
+            leaf_index = ("tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV": address);
+            leaf_position = 0n;
+            siblings = (map end : map(nat, address_tree_node));
+          end;
+          interval_inclusion_proof = record
+            leaf_index = 0n;
+            leaf_position = 0n;
+            siblings = (map
+              0n -> record
+                data = ("0000": bytes);
+                start = 0n;
+              end
+            end : map(nat, interval_tree_node));
+          end;
+        end,
+        ("0000": bytes)
+      )`)
+
+      const result = await invokeTest({
+        contractPath: 'contracts/test.ligo',
+        entryPoint: 'test_verify_inclusion',
+        parameter: testParams,
+        initialStorage,
+        source: 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV'
+      })
+      assert.deepEqual(result.postState, 'true')
+    })
+  })
 })


### PR DESCRIPTION
## What I did

Adding verify_inclusion function. We don't check address tree now because Tezos don't handle multiple token types now. And test cases aren't enough because client didn't implement sha256 tree yet. I wanna reuse test data for client.

## Notice

We should modify client code to support "verify_inclusion" of Tezos.

* interval_tree_node encoding
* get_parent encoding

