### PR TITLE
Debian support for npm test

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,11 @@
       "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
       "dev": true
     },
+    "acorn-es7-plugin": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/acorn-es7-plugin/-/acorn-es7-plugin-1.1.7.tgz",
+      "integrity": "sha1-8u4fMiipDurRJF+asZIusucdM2s="
+    },
     "acorn-jsx": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.1.0.tgz",
@@ -97,6 +102,11 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM="
+    },
     "assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -145,6 +155,11 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
+    },
+    "call-signature": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/call-signature/-/call-signature-0.0.2.tgz",
+      "integrity": "sha1-qEq8glpV70yysCi9dOIFpluaSZY="
     },
     "callsites": {
       "version": "3.1.0",
@@ -283,6 +298,11 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
+    "core-js": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -330,10 +350,14 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
       "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-      "dev": true,
       "requires": {
         "object-keys": "^1.0.12"
       }
+    },
+    "diff-match-patch": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/diff-match-patch/-/diff-match-patch-1.0.4.tgz",
+      "integrity": "sha512-Uv3SW8bmH9nAtHKaKSanOQmj2DnlH65fUpcrMdfdaOxUG02QQ4YGZ8AE7kKOMisF7UqvOlGKVYWRvezdncW9lg=="
     },
     "doctrine": {
       "version": "3.0.0",
@@ -344,11 +368,34 @@
         "esutils": "^2.0.2"
       }
     },
+    "eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="
+    },
     "emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "empower": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/empower/-/empower-1.3.1.tgz",
+      "integrity": "sha512-uB6/ViBaawOO/uujFADTK3SqdYlxYNn+N4usK9MRKZ4Hbn/1QSy8k2PezxCA2/+JGbF8vd/eOfghZ90oOSDZCA==",
+      "requires": {
+        "core-js": "^2.0.0",
+        "empower-core": "^1.2.0"
+      }
+    },
+    "empower-core": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/empower-core/-/empower-core-1.2.0.tgz",
+      "integrity": "sha512-g6+K6Geyc1o6FdXs9HwrXleCFan7d66G5xSCfSF7x1mJDCes6t0om9lFQG3zOrzh3Bkb/45N0cZ5Gqsf7YrzGQ==",
+      "requires": {
+        "call-signature": "0.0.2",
+        "core-js": "^2.0.0"
+      }
     },
     "es-abstract": {
       "version": "1.17.0",
@@ -514,6 +561,14 @@
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "dev": true
     },
+    "espurify": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/espurify/-/espurify-1.8.1.tgz",
+      "integrity": "sha512-ZDko6eY/o+D/gHCWyHTU85mKDgYcS4FJj7S+YD6WIInm7GQ6AnOjmcL4+buFV/JOztVLELi/7MmuGU5NHta0Mg==",
+      "requires": {
+        "core-js": "^2.0.0"
+      }
+    },
     "esquery": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
@@ -535,8 +590,7 @@
     "estraverse": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
+      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -779,6 +833,11 @@
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
+    },
+    "indexof": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
+      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
     },
     "inflight": {
       "version": "1.0.6",
@@ -1166,8 +1225,7 @@
     "object-keys": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
-      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
     },
     "object.assign": {
       "version": "4.1.0",
@@ -1297,6 +1355,122 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.1.tgz",
       "integrity": "sha512-ISBaA8xQNmwELC7eOjqFKMESB2VIqt4PPDD0nsS95b/9dZXvVKOlz9keMSnoGGKcOHXfTvDD6WMaRoSc9UuhRA==",
       "dev": true
+    },
+    "power-assert": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/power-assert/-/power-assert-1.6.1.tgz",
+      "integrity": "sha512-VWkkZV6Y+W8qLX/PtJu2Ur2jDPIs0a5vbP0TpKeybNcIXmT4vcKoVkyTp5lnQvTpY/DxacAZ4RZisHRHLJcAZQ==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "empower": "^1.3.1",
+        "power-assert-formatter": "^1.4.1",
+        "universal-deep-strict-equal": "^1.2.1",
+        "xtend": "^4.0.0"
+      }
+    },
+    "power-assert-context-formatter": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-formatter/-/power-assert-context-formatter-1.2.0.tgz",
+      "integrity": "sha512-HLNEW8Bin+BFCpk/zbyKwkEu9W8/zThIStxGo7weYcFkKgMuGCHUJhvJeBGXDZf0Qm2xis4pbnnciGZiX0EpSg==",
+      "requires": {
+        "core-js": "^2.0.0",
+        "power-assert-context-traversal": "^1.2.0"
+      }
+    },
+    "power-assert-context-reducer-ast": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-reducer-ast/-/power-assert-context-reducer-ast-1.2.0.tgz",
+      "integrity": "sha512-EgOxmZ/Lb7tw4EwSKX7ZnfC0P/qRZFEG28dx/690qvhmOJ6hgThYFm5TUWANDLK5NiNKlPBi5WekVGd2+5wPrw==",
+      "requires": {
+        "acorn": "^5.0.0",
+        "acorn-es7-plugin": "^1.0.12",
+        "core-js": "^2.0.0",
+        "espurify": "^1.6.0",
+        "estraverse": "^4.2.0"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "5.7.4",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.4.tgz",
+          "integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg=="
+        }
+      }
+    },
+    "power-assert-context-traversal": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-context-traversal/-/power-assert-context-traversal-1.2.0.tgz",
+      "integrity": "sha512-NFoHU6g2umNajiP2l4qb0BRWD773Aw9uWdWYH9EQsVwIZnog5bd2YYLFCVvaxWpwNzWeEfZIon2xtyc63026pQ==",
+      "requires": {
+        "core-js": "^2.0.0",
+        "estraverse": "^4.1.0"
+      }
+    },
+    "power-assert-formatter": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/power-assert-formatter/-/power-assert-formatter-1.4.1.tgz",
+      "integrity": "sha1-XcEl7VCj37HdomwZNH879Y7CiEo=",
+      "requires": {
+        "core-js": "^2.0.0",
+        "power-assert-context-formatter": "^1.0.7",
+        "power-assert-context-reducer-ast": "^1.0.7",
+        "power-assert-renderer-assertion": "^1.0.7",
+        "power-assert-renderer-comparison": "^1.0.7",
+        "power-assert-renderer-diagram": "^1.0.7",
+        "power-assert-renderer-file": "^1.0.7"
+      }
+    },
+    "power-assert-renderer-assertion": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-assertion/-/power-assert-renderer-assertion-1.2.0.tgz",
+      "integrity": "sha512-3F7Q1ZLmV2ZCQv7aV7NJLNK9G7QsostrhOU7U0RhEQS/0vhEqrRg2jEJl1jtUL4ZyL2dXUlaaqrmPv5r9kRvIg==",
+      "requires": {
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.2.0"
+      }
+    },
+    "power-assert-renderer-base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-base/-/power-assert-renderer-base-1.1.1.tgz",
+      "integrity": "sha1-lqZQxv0F7hvB9mtUrWFELIs/Y+s="
+    },
+    "power-assert-renderer-comparison": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-comparison/-/power-assert-renderer-comparison-1.2.0.tgz",
+      "integrity": "sha512-7c3RKPDBKK4E3JqdPtYRE9cM8AyX4LC4yfTvvTYyx8zSqmT5kJnXwzR0yWQLOavACllZfwrAGQzFiXPc5sWa+g==",
+      "requires": {
+        "core-js": "^2.0.0",
+        "diff-match-patch": "^1.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "stringifier": "^1.3.0",
+        "type-name": "^2.0.1"
+      }
+    },
+    "power-assert-renderer-diagram": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-diagram/-/power-assert-renderer-diagram-1.2.0.tgz",
+      "integrity": "sha512-JZ6PC+DJPQqfU6dwSmpcoD7gNnb/5U77bU5KgNwPPa+i1Pxiz6UuDeM3EUBlhZ1HvH9tMjI60anqVyi5l2oNdg==",
+      "requires": {
+        "core-js": "^2.0.0",
+        "power-assert-renderer-base": "^1.1.1",
+        "power-assert-util-string-width": "^1.2.0",
+        "stringifier": "^1.3.0"
+      }
+    },
+    "power-assert-renderer-file": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-renderer-file/-/power-assert-renderer-file-1.2.0.tgz",
+      "integrity": "sha512-/oaVrRbeOtGoyyd7e4IdLP/jIIUFJdqJtsYzP9/88R39CMnfF/S/rUc8ZQalENfUfQ/wQHu+XZYRMaCEZmEesg==",
+      "requires": {
+        "power-assert-renderer-base": "^1.1.1"
+      }
+    },
+    "power-assert-util-string-width": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/power-assert-util-string-width/-/power-assert-util-string-width-1.2.0.tgz",
+      "integrity": "sha512-lX90G0igAW0iyORTILZ/QjZWsa1MZ6VVY3L0K86e2eKun3S4LKPH4xZIl8fdeMYLfOjkaszbNSzf1uugLeAm2A==",
+      "requires": {
+        "eastasianwidth": "^0.2.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -1507,6 +1681,16 @@
         "function-bind": "^1.1.1"
       }
     },
+    "stringifier": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/stringifier/-/stringifier-1.4.0.tgz",
+      "integrity": "sha512-cNsMOqqrcbLcHTXEVmkw9y0fwDwkdgtZwlfyolzpQDoAE1xdNGhQhxBUfiDvvZIKl1hnUEgMv66nHwtMz3OjPw==",
+      "requires": {
+        "core-js": "^2.0.0",
+        "traverse": "^0.6.6",
+        "type-name": "^2.0.1"
+      }
+    },
     "strip-ansi": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
@@ -1606,6 +1790,11 @@
         "is-number": "^7.0.0"
       }
     },
+    "traverse": {
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
+      "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc="
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -1632,6 +1821,21 @@
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
       "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
       "dev": true
+    },
+    "type-name": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/type-name/-/type-name-2.0.2.tgz",
+      "integrity": "sha1-7+fUEj2KxSr/9/QMfk3sUmYAj7Q="
+    },
+    "universal-deep-strict-equal": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/universal-deep-strict-equal/-/universal-deep-strict-equal-1.2.2.tgz",
+      "integrity": "sha1-DaSsL3PP95JMgfpN4BjKViyisKc=",
+      "requires": {
+        "array-filter": "^1.0.0",
+        "indexof": "0.0.1",
+        "object-keys": "^1.0.0"
+      }
     },
     "uri-js": {
       "version": "4.2.2",
@@ -1785,6 +1989,11 @@
       "requires": {
         "mkdirp": "^0.5.1"
       }
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y18n": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
     "url": "https://github.com/cryptoeconomicslab/ovm.tz/issues"
   },
   "homepage": "https://github.com/cryptoeconomicslab/ovm.tz#readme",
-  "dependencies": {},
+  "dependencies": {
+    "power-assert": "^1.6.1"
+  },
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -22,15 +22,13 @@
     "url": "https://github.com/cryptoeconomicslab/ovm.tz/issues"
   },
   "homepage": "https://github.com/cryptoeconomicslab/ovm.tz#readme",
-  "dependencies": {
-    "power-assert": "^1.6.1"
-  },
   "devDependencies": {
     "chai": "^4.2.0",
     "eslint": "^6.6.0",
     "eslint-config-prettier": "^6.5.0",
     "eslint-plugin-prettier": "^3.1.1",
     "mocha": "^7.0.0",
+    "power-assert": "^1.6.1",
     "pegjs": "^0.10.0",
     "prettier": "^1.19.1"
   }

--- a/test/codec.test.js
+++ b/test/codec.test.js
@@ -1,4 +1,4 @@
-const assert = require('assert')
+const assert = require('power-assert')
 const { invokeTest, STATUS } = require('./helper/invokeTest')
 const CONTRACT_PATH = 'test/contracts/codec.ligo'
 
@@ -18,7 +18,7 @@ describe('CodecContract', function() {
           entryPoint: 'pack_address',
           initialStorage: `("00": bytes)`
         })
-        assert.deepEqual(
+        assert.deepStrictEqual(
           result.postState,
           '0x050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d'
         )
@@ -32,7 +32,7 @@ describe('CodecContract', function() {
           entryPoint: 'pack_bignumber',
           initialStorage: `("00": bytes)`
         })
-        assert.deepEqual(result.postState, '0x05010000000131')
+        assert.deepStrictEqual(result.postState, '0x05010000000131')
       })
 
       it('packs a record', async () => {
@@ -46,8 +46,11 @@ describe('CodecContract', function() {
           entryPoint: 'pack_sample_record',
           initialStorage: '("00": bytes)'
         })
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, `0x0507070100000004686f67650001`)
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(
+          result.postState,
+          `0x0507070100000004686f67650001`
+        )
       })
 
       it('packs a tuple', async () => {
@@ -62,7 +65,7 @@ describe('CodecContract', function() {
           entryPoint: 'pack_tuple',
           initialStorage: `("00": bytes)`
         })
-        assert.deepEqual(
+        assert.deepStrictEqual(
           result.postState,
           '0x050707070700050a00000016000053c1edca8bd5c21c61d6f1fd091fa51d562aff1d0a0000000568656c6c6f'
         )
@@ -80,7 +83,7 @@ describe('CodecContract', function() {
           entryPoint: 'pack_list_of_int',
           initialStorage: `("00": bytes)`
         })
-        assert.deepEqual(
+        assert.deepStrictEqual(
           result.postState,
           '0x050200000012070400000001070400010002070400020003'
         )
@@ -103,8 +106,8 @@ describe('CodecContract', function() {
           entryPoint: 'pack_list_of_record',
           initialStorage: '("00": bytes)'
         })
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(
           result.postState,
           `0x0502000000220704000007070100000004686f676500010704000107070100000004686f67650001`
         )
@@ -122,7 +125,7 @@ describe('CodecContract', function() {
           entryPoint: 'pack_list_of_tuple',
           initialStorage: `("00": bytes)`
         })
-        assert.deepEqual(
+        assert.deepStrictEqual(
           result.postState,
           '0x0502000000240704000007070a00000005746573743100010704000107070a0000000574657374320002'
         )
@@ -136,7 +139,7 @@ describe('CodecContract', function() {
           entryPoint: 'pack_empty_list',
           initialStorage: `("00": bytes)`
         })
-        assert.deepEqual(result.postState, '0x050200000000')
+        assert.deepStrictEqual(result.postState, '0x050200000000')
       })
 
       it('packs a list of list of integer', async () => {
@@ -163,7 +166,7 @@ describe('CodecContract', function() {
           entryPoint: 'pack_list_of_list_of_int',
           initialStorage: `("00": bytes)`
         })
-        assert.deepEqual(
+        assert.deepStrictEqual(
           result.postState,
           '0x05020000005107040000020000001207040000000107040001000307040002000407040001020000001207040000000207040001000407040002000607040002020000001207040000000a07040001000b07040002000c'
         )
@@ -180,8 +183,8 @@ describe('CodecContract', function() {
           initialStorage: '(None: option(address))'
         })
 
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, [
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(result.postState, [
           'SOME',
           'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV'
         ])
@@ -196,8 +199,8 @@ describe('CodecContract', function() {
           initialStorage: '(None: option(string))'
         })
 
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, ['SOME', '1'])
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(result.postState, ['SOME', '1'])
       })
 
       it('unpacks a record', async () => {
@@ -209,8 +212,8 @@ describe('CodecContract', function() {
           initialStorage: '(None: option(sample_record))'
         })
 
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, [
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(result.postState, [
           'SOME',
           {
             attributeA: 'hoge',
@@ -227,8 +230,8 @@ describe('CodecContract', function() {
           entryPoint: 'unpack_tuple',
           initialStorage: `(None: option(sample_tuple))`
         })
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, [
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(result.postState, [
           'SOME',
           [5, 'tz1TGu6TN5GSez2ndXXeDX6LgUDvLzPLqgYV', '0x68656c6c6f']
         ])
@@ -243,8 +246,11 @@ describe('CodecContract', function() {
           initialStorage: '(None: option(map(nat, int)))'
         })
 
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, ['SOME', [1, 2, 3]])
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(result.postState, [
+          'SOME',
+          { '0': 1, '1': 2, '2': 3 }
+        ])
       })
 
       it('unpacks a list of records', async () => {
@@ -256,19 +262,19 @@ describe('CodecContract', function() {
           initialStorage: '(None: option(map(nat, sample_record)))'
         })
 
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, [
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(result.postState, [
           'SOME',
-          [
-            {
+          {
+            '0': {
               attributeA: 'hoge',
               attributeB: 1
             },
-            {
+            '1': {
               attributeA: 'hoge',
               attributeB: 1
             }
-          ]
+          }
         ])
       })
       it('unpacks a list of tuples', async () => {
@@ -280,13 +286,13 @@ describe('CodecContract', function() {
           initialStorage: '(None: option(map(nat, sample_tuple)))'
         })
 
-        assert.deepEqual(result.status, STATUS.OK)
-        assert.deepEqual(result.postState, [
+        assert.deepStrictEqual(result.status, STATUS.OK)
+        assert.deepStrictEqual(result.postState, [
           'SOME',
-          [
-            ['0x7465737431', 1],
-            ['0x7465737432', 2]
-          ]
+          {
+            '0': ['0x7465737431', 1],
+            '1': ['0x7465737432', 2]
+          }
         ])
       })
     })


### PR DESCRIPTION
- updated 'assert' to 'power-assert'
- updated 'deepEqual' to 'deepStrictEqual'
- updated the unpacked result's list to string-keyed map